### PR TITLE
(WIP) [AEKR-1972] Pointing to the latest delete-constraint image for v5.3.1 and v5.4

### DIFF
--- a/local-installation/config/feder8-local-images.json
+++ b/local-installation/config/feder8-local-images.json
@@ -153,7 +153,7 @@
     },
     { "name": "postgres-omopcdm-delete-constraints-5_4",
       "image": "postgres-omopcdm-delete-constraints",
-      "tag":  "5.4-2.0.1",
+      "tag":  "5.4-2.0.2",
       "public": false
     },
     { "name": "postgres-omopcdm-update-custom-concepts",

--- a/local-installation/config/feder8-local-images.json
+++ b/local-installation/config/feder8-local-images.json
@@ -147,11 +147,11 @@
       "public": false
     },
     { "name": "postgres-omopcdm-delete-constraints",
-      "image": "postgres",
-      "tag":  "omopcdm-delete-constraints-2.0.0",
+      "image": "postgres-omopcdm-delete-constraints",
+      "tag":  "5.3.1-2.0.2",
       "public": false
     },
-    { "name": "postgres-omopcdm-delete-constraints-5_4",
+    { "name": "postgres-omopcdm-delete-constraints",
       "image": "postgres-omopcdm-delete-constraints",
       "tag":  "5.4-2.0.2",
       "public": false


### PR DESCRIPTION
Images to delete-constraints for both OMOP CDM version have been updated - not tested as image not push to harbor yet