### PR TITLE
[AEKR-2237] Upgrading tag from v2.2.6 to v2.3.0

### DIFF
--- a/local-installation/helper-scripts/start-feder8.cmd
+++ b/local-installation/helper-scripts/start-feder8.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/helper-scripts/start-feder8.sh
+++ b/local-installation/helper-scripts/start-feder8.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 if systemctl show --property ActiveState docker &> /dev/null; then

--- a/local-installation/offline-helper-scripts/start-feder8-offline.cmd
+++ b/local-installation/offline-helper-scripts/start-feder8-offline.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET PYTHON_VERSION=3.11
 SET REGISTRY=harbor.honeur.org
 

--- a/local-installation/offline-helper-scripts/start-feder8-offline.sh
+++ b/local-installation/offline-helper-scripts/start-feder8-offline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 PYTHON_VERSION=3.11
 REGISTRY=harbor.honeur.org
 

--- a/local-installation/separate-scripts/backup-full.cmd
+++ b/local-installation/separate-scripts/backup-full.cmd
@@ -1,4 +1,4 @@
 @ECHO off
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 docker run --rm -it --name feder8-installer -e CURRENT_DIRECTORY=%CD% -e IS_WINDOWS=true -e DOCKER_CERT_SUPPORT=false -v /var/run/docker.sock:/var/run/docker.sock %REGISTRY%/library/install-script:%TAG% feder8 init backup

--- a/local-installation/separate-scripts/backup-full.sh
+++ b/local-installation/separate-scripts/backup-full.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 docker run --rm -it --name feder8-installer -e CURRENT_DIRECTORY=$(pwd) -e IS_WINDOWS=false -e DOCKER_CERT_SUPPORT=false -v /var/run/docker.sock:/var/run/docker.sock ${REGISTRY}/library/install-script:${TAG} feder8 init backup

--- a/local-installation/separate-scripts/change-hostname.sh
+++ b/local-installation/separate-scripts/change-hostname.sh
@@ -3,7 +3,7 @@
 REGISTRY=harbor.honeur.org
 REPOSITORY=library
 IMAGE=install-script
-TAG=2.2.4
+TAG=2.3.0
 
 if systemctl show --property ActiveState docker &> /dev/null; then
     DOCKER_CERT_SUPPORT=true

--- a/local-installation/separate-scripts/fix-default-privileges.cmd
+++ b/local-installation/separate-scripts/fix-default-privileges.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/fix-default-privileges.sh
+++ b/local-installation/separate-scripts/fix-default-privileges.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 if systemctl show --property ActiveState docker &> /dev/null; then

--- a/local-installation/separate-scripts/restore.cmd
+++ b/local-installation/separate-scripts/restore.cmd
@@ -1,4 +1,4 @@
 @ECHO off
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 docker run --rm -it --name feder8-installer -e CURRENT_DIRECTORY=%CD% -e IS_WINDOWS=true -e DOCKER_CERT_SUPPORT=false -v /var/run/docker.sock:/var/run/docker.sock %REGISTRY%/library/install-script:%TAG% feder8 init restore

--- a/local-installation/separate-scripts/restore.sh
+++ b/local-installation/separate-scripts/restore.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 docker run --rm -it --name feder8-installer -e CURRENT_DIRECTORY=$(pwd) -e IS_WINDOWS=false -e DOCKER_CERT_SUPPORT=false -v /var/run/docker.sock:/var/run/docker.sock ${REGISTRY}/library/install-script:${TAG} feder8 init restore

--- a/local-installation/separate-scripts/start-add-indexes-and-constraints.cmd
+++ b/local-installation/separate-scripts/start-add-indexes-and-constraints.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/start-add-indexes-and-constraints.sh
+++ b/local-installation/separate-scripts/start-add-indexes-and-constraints.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 docker pull ${REGISTRY}/library/install-script:${TAG}

--- a/local-installation/separate-scripts/start-custom-concepts-update-offline.sh
+++ b/local-installation/separate-scripts/start-custom-concepts-update-offline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 echo "Downloading configuration files..."

--- a/local-installation/separate-scripts/start-custom-concepts-update.cmd
+++ b/local-installation/separate-scripts/start-custom-concepts-update.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/start-custom-concepts-update.sh
+++ b/local-installation/separate-scripts/start-custom-concepts-update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 docker pull ${REGISTRY}/library/install-script:${TAG}

--- a/local-installation/separate-scripts/start-dbeaver.cmd
+++ b/local-installation/separate-scripts/start-dbeaver.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/start-dbeaver.sh
+++ b/local-installation/separate-scripts/start-dbeaver.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 docker pull ${REGISTRY}/library/install-script:${TAG}

--- a/local-installation/separate-scripts/start-distributed-analytics.cmd
+++ b/local-installation/separate-scripts/start-distributed-analytics.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 set "ORGANIZATION="

--- a/local-installation/separate-scripts/start-distributed-analytics.sh
+++ b/local-installation/separate-scripts/start-distributed-analytics.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 read -p "Enter organization name: " ORGANIZATION

--- a/local-installation/separate-scripts/start-feder8-studio.cmd
+++ b/local-installation/separate-scripts/start-feder8-studio.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/start-feder8-studio.sh
+++ b/local-installation/separate-scripts/start-feder8-studio.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 if systemctl show --property ActiveState docker &> /dev/null; then

--- a/local-installation/separate-scripts/start-vocabulary-update.cmd
+++ b/local-installation/separate-scripts/start-vocabulary-update.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/start-vocabulary-update.sh
+++ b/local-installation/separate-scripts/start-vocabulary-update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 docker pull ${REGISTRY}/library/install-script:${TAG}

--- a/local-installation/separate-scripts/start-zeppelin.cmd
+++ b/local-installation/separate-scripts/start-zeppelin.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/start-zeppelin.sh
+++ b/local-installation/separate-scripts/start-zeppelin.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 docker pull ${REGISTRY}/library/install-script:${TAG}

--- a/local-installation/separate-scripts/uninstall-feder8.cmd
+++ b/local-installation/separate-scripts/uninstall-feder8.cmd
@@ -1,6 +1,6 @@
 @ECHO off
 
-SET TAG=2.2.4
+SET TAG=2.3.0
 SET REGISTRY=harbor.honeur.org
 
 docker pull %REGISTRY%/library/install-script:%TAG%

--- a/local-installation/separate-scripts/uninstall-feder8.sh
+++ b/local-installation/separate-scripts/uninstall-feder8.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-TAG=2.2.4
+TAG=2.3.0
 REGISTRY=harbor.honeur.org
 
 docker pull ${REGISTRY}/library/install-script:${TAG}

--- a/local-installation/separate-scripts/upgrade-omopcdm-schema-53-to-54.sh
+++ b/local-installation/separate-scripts/upgrade-omopcdm-schema-53-to-54.sh
@@ -62,6 +62,6 @@ docker run --rm --name  omopcdm-add-base-indexes \
 $REGISTRY/$REPOSITORY/$IMAGE:$TAG
 
 echo "Load vocabularies in $NEW_CDM_SCHEMA"
-TAG=2.2.4
+TAG=2.3.0
 docker pull ${REGISTRY}/library/install-script:${TAG}
 docker run --rm -it --name feder8-installer -e CURRENT_DIRECTORY="$(pwd)" -e IS_WINDOWS=false -e DOCKER_CERT_SUPPORT=false -v /var/run/docker.sock:/var/run/docker.sock ${REGISTRY}/library/install-script:${TAG} feder8 init update-vocabulary -ta honeur


### PR DESCRIPTION
Testing v2.3.0 without updating yet the feder8-local-images.json to postgres v17: 

**Scenario - Local installation with postgres v13**

1) Using install-script:v2.3.0 to just do un upgrade of the local installation with postgres v13 -> OK  
2) Using install-script:v2.3.0 to do custom concept vocabulary update (still postgres v13) -> OK  
2) Using install-script:v2.3.0 to do a vocabulary update (still postgres v13) -> OK  